### PR TITLE
Version Bump Needed

### DIFF
--- a/mysql/config/defaults
+++ b/mysql/config/defaults
@@ -1,1 +1,1 @@
-version=5.5.19
+version=5.5.29


### PR DESCRIPTION
5.5.19 is no longer available for download from the site you're referencing.  Bumped the version to 5.5.29.
